### PR TITLE
updates cookbook to work with the updated source path

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,6 +26,10 @@ else
   include_recipe "sphinx::source"
 end
 
+directory node['sphinx']['install_path'] do
+  recursive true
+end
+
 template "#{node['sphinx']['install_path']}/sphinx.conf" do
   source "sphinx.conf.erb"
   owner node[:sphinx][:user]

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -7,9 +7,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,18 +19,21 @@
 
 include_recipe "build-essential"
 
-remote_file "/tmp/sphinx-#{node[:sphinx][:version]}.tar.gz" do
+sphinx_path = "/tmp/sphinx-#{node[:sphinx][:version]}-release"
+sphinx_tar = "#{sphinx_path}.tar.gz"
+
+remote_file sphinx_tar do
   source "#{node[:sphinx][:url]}"
-  not_if { ::File.exists?("/tmp/sphinx-#{node[:sphinx][:version]}.tar.gz") }
+  not_if { ::File.exists?(sphinx_tar) }
 end
 
 execute "Extract Sphinx source" do
   cwd "/tmp"
-  command "tar -zxvf /tmp/sphinx-#{node[:sphinx][:version]}.tar.gz"
-  not_if { ::File.exists?("/tmp/sphinx-#{node[:sphinx][:version]}") }
+  command "tar -zxvf #{sphinx_tar}"
+  not_if { ::File.exists?(sphinx_path) }
 end
 
-if node[:sphinx][:use_stemmer] 
+if node[:sphinx][:use_stemmer]
   remote_file "/tmp/libstemmer_c.tgz" do
     source node[:sphinx][:stemmer_url]
     not_if { ::File.exists?("/tmp/libstemmer_c.tgz") }
@@ -38,16 +41,18 @@ if node[:sphinx][:use_stemmer]
 
   execute "Extract libstemmer source" do
     cwd "/tmp"
-    command "tar -C /tmp/sphinx-#{node[:sphinx][:version]} -zxf libstemmer_c.tgz"
-    not_if { ::File.exists?("/tmp/sphinx-#{node[:sphinx][:version]}/libstemmer_c/src_c") }
+    command "tar -C #{sphinx_path} -zxf libstemmer_c.tgz"
+    not_if { ::File.exists?("#{sphinx_path}/libstemmer_c/src_c") }
   end
 end
 
 bash "Build and Install Sphinx Search" do
-  cwd "/tmp/sphinx-#{node[:sphinx][:version]}"
+  cwd sphinx_path
+  # use trailing && to break on the first thing.
+  # Otherwise the whole block depends on the last line
   code <<-EOH
-    ./configure #{node[:sphinx][:configure_flags].join(" ")}
-    make
+    ./configure #{node[:sphinx][:configure_flags].join(" ")} &&
+    make &&
     make install
   EOH
   not_if { ::File.exists?("/usr/local/bin/searchd") }


### PR DESCRIPTION
This "works" on a bare Scientific Linux 6 OpenVZ container.

However,

```
$ searchd
Sphinx 2.0.4-release (r3135)
Copyright (c) 2001-2012, Andrew Aksyonoff
Copyright (c) 2008-2012, Sphinx Technologies Inc (http://sphinxsearch.com)

using config file '/usr/local/etc/sphinx.conf'...
FATAL: 'searchd' config section not found in '/usr/local/etc/sphinx.conf'
```

and

```
searchd -c /opt/sphinx/sphinx.conf 
Sphinx 2.0.4-release (r3135)
Copyright (c) 2001-2012, Andrew Aksyonoff
Copyright (c) 2008-2012, Sphinx Technologies Inc (http://sphinxsearch.com)

using config file '/opt/sphinx/sphinx.conf'...
FATAL: 'searchd' config section not found in '/opt/sphinx/sphinx.conf'
```

Looking at the Makefile there doesn't seem to be a good way to overwrite the install paths. sysconfdir won't take and DEST_DIR just prepends it so you get silly paths like '/opt/sphinx/usr/local/etc/sphinx.conf'
- make install now hits /usr/local/etc/sphinx.conf.dist thus /opt/sphinx isn't there for the template
- they changed the tar contents to sphinx-version-relase, which broke ./configure when cwd wasn't there
  *\* I tried to find a better way such as tar -C directory, but that put the directory in the directory. Didn't find a better way in 2 minutes so I just appended -release to match the current version
- Added trailing && so the code block fails on the failing command, instead of saying make install and the error is make: Error cannot find Makefile or something silly.
