### PR TITLE
Guess `package_name` unless explicitly set via attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,7 @@
 default[:sphinx][:use_package]  = false
 default[:sphinx][:install_path] = "/opt/sphinx"
 default[:sphinx][:version]      = nil
+default[:sphinx][:package_name] = nil # depends on platform_family when not explicit
 default[:sphinx][:url]          = "http://sphinxsearch.com/files/sphinx-#{sphinx[:version]}-release.tar.gz"
 default[:sphinx][:stemmer_url]  = "http://snowball.tartarus.org/dist/libstemmer_c.tgz"
 default[:sphinx][:user]         = 'root'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,6 +7,10 @@ default[:sphinx][:stemmer_url]  = "http://snowball.tartarus.org/dist/libstemmer_
 default[:sphinx][:user]         = 'root'
 default[:sphinx][:group]        = 'root'
 
+# when installing package in RHEL/CentOS include yum::epel by default
+# set to 'nil' to not include recipes before installing sphinx package
+default[:sphinx][:yum_repo]     = 'yum::epel'
+
 # tunable options
 default[:sphinx][:use_stemmer]  = false
 default[:sphinx][:use_mysql]    = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,6 +16,7 @@ provides         "sphinx::source"
 depends          "build-essential"
 depends          "mysql"
 depends          "postgresql"
+depends          "yum"
 
 supports         "centos"
 supports         "rhel"

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -17,7 +17,17 @@
 # limitations under the License.
 #
 
+case node['platform_family']
+when 'debian'
+  sphinx_package_name = 'sphinxsearch'
+else
+  sphinx_package_name= 'sphinx'
+end
+
+sphinx_package_name = node[:sphinx][:package_name] || sphinx_package_name
+
 package "sphinx" do
   version node[:sphinx][:version] unless node[:sphinx][:version].nil?
   action :install
+  package_name sphinx_package_name
 end

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -20,6 +20,9 @@
 case node['platform_family']
 when 'debian'
   sphinx_package_name = 'sphinxsearch'
+when 'rhel'
+  sphinx_package_name = 'sphinx'
+  include_recipe node[:sphinx][:yum_repo] unless node[:sphinx][:yum_repo].empty?
 else
   sphinx_package_name= 'sphinx'
 end


### PR DESCRIPTION
Debian and RHEL platform families unfortunately have different names for the sphinx package, `sphinxsearch` in debian and `sphinx` in RHEL EPEL repository.
