### PR TITLE
Use ```sphinx[:install_path]``` as prefix to install built sphinx source

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,6 +12,7 @@ default[:sphinx][:use_mysql]    = false
 default[:sphinx][:use_postgres] = false
 
 default[:sphinx][:configure_flags] = [
+  "--prefix=#{sphinx[:install_path]}",
   "#{sphinx[:use_stemmer] ? '--with-stemmer' : '--without-stemmer'}",
   "#{sphinx[:use_mysql] ? '--with-mysql' : '--without-mysql'}",
   "#{sphinx[:use_postgres] ? '--with-pgsql' : '--without-pgsql'}"

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -55,7 +55,7 @@ bash "Build and Install Sphinx Search" do
     make &&
     make install
   EOH
-  not_if { ::File.exists?("/usr/local/bin/searchd") }
+  not_if { ::File.exists?( ::File.join(node[:sphinx][:install_path],'bin','searchd') ) }
   # add additional test to verify of searchd is same as version of sphinx we are installing
   #  && system("#{node[:sphinx][:install_path]}/bin/ree-version | grep -q '#{node[:sphinx][:version]}$'")
 end


### PR DESCRIPTION
Add the `--prefix=/some/where` configuration flag to install sphinx to the specified install location via `sphinx[:install_path]` instead of to the default `/usr/local`.
