### PR TITLE
Valid build options for libstemmer

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@ default[:sphinx][:use_postgres] = false
 
 default[:sphinx][:configure_flags] = [
   "--prefix=#{sphinx[:install_path]}",
-  "#{sphinx[:use_stemmer] ? '--with-stemmer' : '--without-stemmer'}",
+  "#{sphinx[:use_stemmer] ? '--with-libstemmer' : '--without-libstemmer'}",
   "#{sphinx[:use_mysql] ? '--with-mysql' : '--without-mysql'}",
   "#{sphinx[:use_postgres] ? '--with-pgsql' : '--without-pgsql'}"
 ]


### PR DESCRIPTION
According to the sphinx documentation. The correct build options for compiling libstemmer  are --with-libstemmer not --with-stemmer

> Additional stemmers provided by Snowball project libstemmer library can be enabled at compile time using **--with-libstemmer** configure option. Built-in English and Russian stemmers should be faster than their libstemmer counterparts, but can produce slightly different results, because they are based on an older version.

http://sphinxsearch.com/docs/current.html#installation
