### PR TITLE
Support for extra configure flags

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,6 +22,7 @@ default[:sphinx][:configure_flags] = [
   sphinx[:use_mysql] ? '--with-mysql' : '--without-mysql',
   sphinx[:use_postgres] ? '--with-pgsql' : '--without-pgsql'
 ]
+default[:sphinx][:extra_configure_flags] = []
 
 default[:sphinx][:searchd][:listen] = ["0.0.0.0:9312"]
 default[:sphinx][:searchd][:log] = "/var/log/sphinx/sphinx.log"

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -52,7 +52,7 @@ bash "Build and Install Sphinx Search" do
   # use trailing && to break on the first thing.
   # Otherwise the whole block depends on the last line
   code <<-EOH
-    ./configure #{node[:sphinx][:configure_flags].join(" ")} &&
+    ./configure #{node[:sphinx][:configure_flags].concat(node[:sphinx][:extra_configure_flags]).uniq.join(" ")} &&
     make &&
     make install
   EOH


### PR DESCRIPTION
Extra configure flags can now be passed that supplement the auto-generated ones, via the `extra_configure_flags` attribute.  I added this as a new attribute for the sake of not breaking the current functionality, where overriding the `configure_flags` attribute would completely override the auto-generated configure flags.
