### PR TITLE
Better handling of custom bindir when building from source

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,6 @@
 default[:sphinx][:use_package]  = false
 default[:sphinx][:install_path] = "/opt/sphinx"
+default[:sphinx][:binary_path]  = "#{sphinx[:install_path]}/bin"
 default[:sphinx][:version]      = nil
 default[:sphinx][:package_name] = nil # depends on platform_family when not explicit
 default[:sphinx][:url]          = nil


### PR DESCRIPTION
The binary directory can now be specified when building from source using an attribute, which allows the presence of searchd to be more accurately queried.  The check for the existence of searchd has also been extended to take the version number into account, if the version attribute has been explicitly set.
