### PR TITLE
Fix undefined method error when sphinx exists and the version has been specified

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -103,7 +103,7 @@ bash "Build and Install Sphinx Search" do
     searchd_version_correct = searchd_present
 
     if searchd_present and node[:sphinx][:version]
-      searchd_version_correct = system("#{searchd} -h | head -1 | grep -q \"#{node[:sphinx][:version]}[^\.]\"")
+      searchd_version_correct = system("#{searchd_binary} -h | head -1 | grep -q \"#{node[:sphinx][:version]}[^\.]\"")
     end
 
     searchd_present && searchd_version_correct


### PR DESCRIPTION
The wrong name is used in the interpolation so the system command fails with 

```
NoMethodError: bash[Build and Install Sphinx Search] (sphinx::source line 93) had an error: NoMethodError: undefined method `searchd' for Chef::Resource::Bash
```

Above the system method call the binary name is actually stored in searchd_binary not searchd
