### PR TITLE
loose dependencies on other cookbooks

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -28,7 +28,7 @@
       "locked_version": "3.0.4"
     },
     "postgresql": {
-      "locked_version": "1.0.0"
+      "locked_version": "3.3.4"
     },
     "chef_handler": {
       "locked_version": "1.1.4"

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -10,13 +10,13 @@
       "path": "./test/cookbooks/sphinx_test"
     },
     "build-essential": {
-      "locked_version": "1.1.2"
+      "locked_version": "1.4.2"
     },
     "mysql": {
-      "locked_version": "3.0.2"
+      "locked_version": "3.0.4"
     },
     "openssl": {
-      "locked_version": "1.0.0"
+      "locked_version": "1.1.0"
     },
     "percona": {
       "locked_version": "0.14.5"
@@ -25,7 +25,7 @@
       "locked_version": "2.1.1"
     },
     "yum": {
-      "locked_version": "2.3.2"
+      "locked_version": "3.0.4"
     },
     "postgresql": {
       "locked_version": "1.0.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ provides         "sphinx::source"
 depends          "build-essential", ">= 1.1.2"
 depends          "mysql"
 depends          "percona"
-depends          "postgresql", "1.0.0"
+depends          "postgresql", ">= 1.0.0"
 depends          "yum", ">= 2.0.0"
 depends          "apt"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ provides         "sphinx::source"
 depends          "build-essential", ">= 1.1.2"
 depends          "mysql"
 depends          "percona"
-depends          "postgresql", ">= 1.0.0"
+depends          "postgresql", "1.0.0"
 depends          "yum", ">= 2.0.0"
 depends          "apt"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,10 +13,10 @@ provides         "sphinx::default"
 provides         "sphinx::package"
 provides         "sphinx::source"
 
-depends          "build-essential", "1.1.2"
+depends          "build-essential", ">= 1.1.2"
 depends          "mysql"
 depends          "percona"
-depends          "postgresql", "1.0.0"
+depends          "postgresql", ">= 1.0.0"
 depends          "yum", ">= 2.0.0"
 depends          "apt"
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -7,6 +7,7 @@ describe 'sphinx::default' do
         runner = ChefSpec::Runner.new()
         runner.node.set['sphinx']['install_method'] = 'package'
         runner.node.set['platform_family'] = 'debian'
+        runner.node.set['lsb']['codename'] = 'precise'
         runner.converge('sphinx::default')
       end
 
@@ -37,6 +38,7 @@ describe 'sphinx::default' do
             runner = ChefSpec::Runner.new(:log_level => :debug)
             runner.node.set['sphinx']['version'] = '2.0.8'
             runner.node.set['platform_family'] = 'debian'
+            runner.node.set['lsb']['codename'] = 'precise'
             runner.converge('sphinx::default')
           end
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -30,25 +30,21 @@ describe 'sphinx::default' do
   end
 
   context 'installation method: source' do
-    context 'retrieve method: http' do
-      context 'version: 2.0.8' do
-        let(:chef_run) do
-          runner = ChefSpec::Runner.new(:log_level => :debug)
-          runner.node.set['sphinx']['version'] = '2.0.8'
-          runner.converge('sphinx::default')
-        end
+    context 'platform: debian' do
+      context 'retrieve method: http' do
+        context 'version: 2.0.8' do
+          let(:chef_run) do
+            runner = ChefSpec::Runner.new(:log_level => :debug)
+            runner.node.set['sphinx']['version'] = '2.0.8'
+            runner.node.set['platform_family'] = 'debian'
+            runner.converge('sphinx::default')
+          end
 
-        it 'should create a sphinx config with the appropriate install_path' do
-          regex = /Put files to be included in \/usr\/local\/conf.d/
-          expect(chef_run).to render_file('/usr/local/sphinx.conf').with_content(regex)
+          it 'should create a sphinx config with the appropriate install_path' do
+            regex = /Put files to be included in \/usr\/local\/conf.d/
+            expect(chef_run).to render_file('/usr/local/sphinx.conf').with_content(regex)
+          end
         end
-
-#        it 'should create a remote file ' do
-#          expect(chef_run).to create_remote_file('/tmp/sphinx-2.0.8-release.tar.gz')
-#          expect(runner).to create_remote_file_if_missing('sphinx-2.0.8-release.tar.gz').with(
-#            :source => 'http://sphinxsearch.com/files/sphinx-2.0.8-release.tar.gz'
-#          )
-#        end
       end
     end
   end


### PR DESCRIPTION
Allow new-er versions of `build-essential` and `postgresql` cookbooks to co-exist with `sphinx`. The strict dependency rules cause tools like `librarian-chef` to fail when this cookbook is used with other cookbooks (like `nginx`) that require higher versions of `build-essential`.

Example error:

```
/...x.../bundle/ruby/2.0.0/gems/librarian-chef-0.0.2/lib/librarian/chef/source/site.rb:309:in `unpack_package!': The package archive has too many children! (RuntimeError)
        from /...x.../bundle/ruby/2.0.0/gems/librarian-chef-0.0.2/lib/librarian/chef/source/site.rb:224:in `cache_version_uri_unpacked!'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-chef-0.0.2/lib/librarian/chef/source/site.rb:93:in `block in version_uri_manifest'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-chef-0.0.2/lib/librarian/chef/source/site.rb:378:in `memo'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-chef-0.0.2/lib/librarian/chef/source/site.rb:92:in `version_uri_manifest'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-chef-0.0.2/lib/librarian/chef/source/site.rb:88:in `version_manifest'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-chef-0.0.2/lib/librarian/chef/source/site.rb:54:in `version_dependencies'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-chef-0.0.2/lib/librarian/chef/source/site.rb:459:in `fetch_dependencies'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/manifest.rb:121:in `fetch_dependencies!'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/manifest.rb:113:in `fetched_dependencies'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/manifest.rb:77:in `dependencies'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:131:in `sourced_dependencies_for_manifest'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:60:in `block in recursive_resolve'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:143:in `block (3 levels) in resolving_dependency_map_find_manifests'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:176:in `block in scope_checking_manifest'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:208:in `scope'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:175:in `scope_checking_manifest'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:142:in `block (2 levels) in resolving_dependency_map_find_manifests'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:196:in `block in map_find'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:195:in `each'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:195:in `map_find'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:141:in `block in resolving_dependency_map_find_manifests'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:154:in `block (2 levels) in scope_resolving_dependency'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:168:in `block in scope_checking_manifests'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:208:in `scope'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:167:in `scope_checking_manifests'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:153:in `block in scope_resolving_dependency'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:208:in `scope'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:152:in `scope_resolving_dependency'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:140:in `resolving_dependency_map_find_manifests'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:56:in `recursive_resolve'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver/implementation.rb:32:in `resolve'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/resolver.rb:16:in `resolve'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/action/resolve.rb:26:in `run'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/cli.rb:169:in `resolve!'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-chef-0.0.2/lib/librarian/chef/cli.rb:41:in `install'
        from /...x.../bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
        from /...x.../bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
        from /...x.../bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
        from /...x.../bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/cli.rb:26:in `block (2 levels) in bin!'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/cli.rb:31:in `returning_status'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/cli.rb:26:in `block in bin!'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/cli.rb:47:in `with_environment'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-0.1.1/lib/librarian/cli.rb:26:in `bin!'
        from /...x.../bundle/ruby/2.0.0/gems/librarian-chef-0.0.2/bin/librarian-chef:7:in `<top (required)>'
        from /...x.../bundle/ruby/2.0.0/bin/librarian-chef:23:in `load'
        from /...x.../bundle/ruby/2.0.0/bin/librarian-chef:23:in `<main>'
```
