### PR TITLE
add back missing variables used when use_stemmer=true

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -1,5 +1,8 @@
 include_recipe "build-essential"
 
+cache_path  = Chef::Config[:file_cache_path]
+sphinx_path = File.join(cache_path, 'sphinx')
+
 # Setup directory structures
 directory node[:sphinx][:source][:install_path] do
   recursive true


### PR DESCRIPTION
When `source` cookbook was refactored into http and svn, some variables got removed that are still used when `use_stemmer=true`.
