### PR TITLE
Fix tests for loose dependencies

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -28,7 +28,7 @@
       "locked_version": "3.0.4"
     },
     "postgresql": {
-      "locked_version": "1.0.0"
+      "locked_version": "3.3.4"
     },
     "chef_handler": {
       "locked_version": "1.1.4"

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -10,13 +10,13 @@
       "path": "./test/cookbooks/sphinx_test"
     },
     "build-essential": {
-      "locked_version": "1.1.2"
+      "locked_version": "1.4.2"
     },
     "mysql": {
-      "locked_version": "3.0.2"
+      "locked_version": "3.0.4"
     },
     "openssl": {
-      "locked_version": "1.0.0"
+      "locked_version": "1.1.0"
     },
     "percona": {
       "locked_version": "0.14.5"
@@ -25,7 +25,7 @@
       "locked_version": "2.1.1"
     },
     "yum": {
-      "locked_version": "2.3.2"
+      "locked_version": "3.0.4"
     },
     "postgresql": {
       "locked_version": "1.0.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ provides         "sphinx::source"
 depends          "build-essential", ">= 1.1.2"
 depends          "mysql"
 depends          "percona"
-depends          "postgresql", "1.0.0"
+depends          "postgresql", ">= 1.0.0"
 depends          "yum", ">= 2.0.0"
 depends          "apt"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ provides         "sphinx::source"
 depends          "build-essential", ">= 1.1.2"
 depends          "mysql"
 depends          "percona"
-depends          "postgresql", ">= 1.0.0"
+depends          "postgresql", "1.0.0"
 depends          "yum", ">= 2.0.0"
 depends          "apt"
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -7,6 +7,7 @@ describe 'sphinx::default' do
         runner = ChefSpec::Runner.new()
         runner.node.set['sphinx']['install_method'] = 'package'
         runner.node.set['platform_family'] = 'debian'
+        runner.node.set['lsb']['codename'] = 'precise'
         runner.converge('sphinx::default')
       end
 
@@ -37,6 +38,7 @@ describe 'sphinx::default' do
             runner = ChefSpec::Runner.new(:log_level => :debug)
             runner.node.set['sphinx']['version'] = '2.0.8'
             runner.node.set['platform_family'] = 'debian'
+            runner.node.set['lsb']['codename'] = 'precise'
             runner.converge('sphinx::default')
           end
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -30,25 +30,21 @@ describe 'sphinx::default' do
   end
 
   context 'installation method: source' do
-    context 'retrieve method: http' do
-      context 'version: 2.0.8' do
-        let(:chef_run) do
-          runner = ChefSpec::Runner.new(:log_level => :debug)
-          runner.node.set['sphinx']['version'] = '2.0.8'
-          runner.converge('sphinx::default')
-        end
+    context 'platform: debian' do
+      context 'retrieve method: http' do
+        context 'version: 2.0.8' do
+          let(:chef_run) do
+            runner = ChefSpec::Runner.new(:log_level => :debug)
+            runner.node.set['sphinx']['version'] = '2.0.8'
+            runner.node.set['platform_family'] = 'debian'
+            runner.converge('sphinx::default')
+          end
 
-        it 'should create a sphinx config with the appropriate install_path' do
-          regex = /Put files to be included in \/usr\/local\/conf.d/
-          expect(chef_run).to render_file('/usr/local/sphinx.conf').with_content(regex)
+          it 'should create a sphinx config with the appropriate install_path' do
+            regex = /Put files to be included in \/usr\/local\/conf.d/
+            expect(chef_run).to render_file('/usr/local/sphinx.conf').with_content(regex)
+          end
         end
-
-#        it 'should create a remote file ' do
-#          expect(chef_run).to create_remote_file('/tmp/sphinx-2.0.8-release.tar.gz')
-#          expect(runner).to create_remote_file_if_missing('sphinx-2.0.8-release.tar.gz').with(
-#            :source => 'http://sphinxsearch.com/files/sphinx-2.0.8-release.tar.gz'
-#          )
-#        end
       end
     end
   end


### PR DESCRIPTION
This fixes the failing tests in issue #26 - both are issues with fauxhai - the source test is missing platform (now required in build-essential), the debian tests are failing due to missing lsb setting
