### PR TITLE
MariaDB Support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,6 +6,7 @@ default[:sphinx][:group]          = 'root'
 default[:sphinx][:use_stemmer]    = false
 default[:sphinx][:use_mysql]      = false
 default[:sphinx][:use_percona]    = false
+default[:sphinx][:use_mariadb]    = false
 default[:sphinx][:use_postgres]   = false
 
 # Source Installation Settings

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,4 +1,5 @@
 include_recipe "percona::client" if node[:sphinx][:use_percona]
 include_recipe "mysql::client" if node[:sphinx][:use_mysql]
+include_recipe "mariadb::client" if node[:sphinx][:use_mariadb]
 include_recipe "postgresql::client" if node[:sphinx][:use_postgres]
 include_recipe "sphinx::#{node[:sphinx][:install_method]}"

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -24,9 +24,10 @@ directory "#{node[:sphinx][:source][:install_path]}/conf.d" do
   mode '0755'
 end
 
+
 # Install required dependency when building from source
 # against Percona server
-if node[:sphinx][:use_percona]
+if (node[:sphinx][:use_percona] or node[:sphinx][:use_mariadb])
   case node[:platform_family]
   when 'debian'
     package 'libssl-dev'
@@ -59,8 +60,7 @@ if configure_flags.empty?
     "--bindir=#{node[:sphinx][:source][:binary_path]}",
     node[:sphinx][:use_stemmer] ? '--with-libstemmer' : '--without-libstemmer',
     (node[:sphinx][:use_mysql] or node[:sphinx][:use_percona] or node[:sphinx][:use_mariadb]) ? '--with-mysql' : '--without-mysql',
-    node[:sphinx][:use_postgres] ? '--with-pgsql' : '--without-pgsql',
-    node[:sphinx][:use_mariadb] ? '--with-mysql-includes=/usr/include/mysql' : ''
+    node[:sphinx][:use_postgres] ? '--with-pgsql' : '--without-pgsql'
   ]
 end
 

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -59,7 +59,8 @@ if configure_flags.empty?
     "--bindir=#{node[:sphinx][:source][:binary_path]}",
     node[:sphinx][:use_stemmer] ? '--with-libstemmer' : '--without-libstemmer',
     (node[:sphinx][:use_mysql] or node[:sphinx][:use_percona] or node[:sphinx][:use_mariadb]) ? '--with-mysql' : '--without-mysql',
-    node[:sphinx][:use_postgres] ? '--with-pgsql' : '--without-pgsql'
+    node[:sphinx][:use_postgres] ? '--with-pgsql' : '--without-pgsql',
+    node[:sphinx][:use_mariadb] ? '--with-mysql-includes=/usr/include/mysql' : ''
   ]
 end
 

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -58,7 +58,7 @@ if configure_flags.empty?
     "--prefix=#{node[:sphinx][:source][:install_path]}",
     "--bindir=#{node[:sphinx][:source][:binary_path]}",
     node[:sphinx][:use_stemmer] ? '--with-libstemmer' : '--without-libstemmer',
-    (node[:sphinx][:use_mysql] or node[:sphinx][:use_percona]) ? '--with-mysql' : '--without-mysql',
+    (node[:sphinx][:use_mysql] or node[:sphinx][:use_percona] or node[:sphinx][:use_mariadb]) ? '--with-mysql' : '--without-mysql',
     node[:sphinx][:use_postgres] ? '--with-pgsql' : '--without-pgsql'
   ]
 end

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -24,9 +24,8 @@ directory "#{node[:sphinx][:source][:install_path]}/conf.d" do
   mode '0755'
 end
 
-
 # Install required dependency when building from source
-# against Percona server
+# against Percona and MariaDB servers
 if (node[:sphinx][:use_percona] or node[:sphinx][:use_mariadb])
   case node[:platform_family]
   when 'debian'


### PR DESCRIPTION
Added support for MariaDB. 

Depends on MariaDB cookbook https://supermarket.chef.io/cookbooks?utf8=%E2%9C%93&q=mariadb

Added attribute `use_mariadb` similar to `use_mysql` and `use_percona`
