### PR TITLE
Support only v6.0.0+ of the mysql cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ provides         "sphinx::source"
 provides         "sphinx::rpm"
 
 depends          "build-essential", ">= 1.1.2"
-depends          "mysql"
+depends          "mysql", ">= 6.0.0"
 depends          "percona"
 depends          "postgresql", ">= 1.0.0"
 depends          "yum"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,4 +1,5 @@
+mysql_client "default" if node[:sphinx][:use_mysql]
 include_recipe "percona::client" if node[:sphinx][:use_percona]
-include_recipe "mysql::client" if node[:sphinx][:use_mysql]
 include_recipe "postgresql::client" if node[:sphinx][:use_postgres]
 include_recipe "sphinx::#{node[:sphinx][:install_method]}"
+


### PR DESCRIPTION
This version removes all the recipes, leaving only resources & providers
